### PR TITLE
Handle APIError when applying manifests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,10 +26,6 @@ jobs:
         uses: actions/checkout@v3
       - name: Install and prepare LXD snap environment
         run: |
-          # Remove docker to avoid network issues https://github.com/charmed-kubernetes/vsphere-cloud-provider/pull/19
-          sudo rm -rf /etc/docker
-          sudo apt-get purge moby-buildx moby-engine moby-cli moby-compose moby-containerd moby-runc -y
-          sudo iptables -P FORWARD ACCEPT
           sudo apt-get remove -qy lxd lxd-client | true
           sudo snap list lxd | true
           sudo snap install lxd --channel=latest/stable

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,9 +23,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Install and prepare LXD snap environment
         run: |
+          # Remove docker to avoid network issues https://github.com/charmed-kubernetes/vsphere-cloud-provider/pull/19
+          sudo rm -rf /etc/docker
+          sudo apt-get purge moby-buildx moby-engine moby-cli moby-compose moby-containerd moby-runc -y
+          sudo iptables -P FORWARD ACCEPT
           sudo apt-get remove -qy lxd lxd-client | true
           sudo snap list lxd | true
           sudo snap install lxd --channel=latest/stable
@@ -69,9 +73,9 @@ jobs:
     timeout-minutes: 90
     steps:
       - name: Check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Setup Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: 3.8
       - name: Setup operator environment
@@ -103,7 +107,7 @@ jobs:
           mv juju-crashdump-* tmp/ | true
       - name: Upload debug artifacts
         if: ${{ failure() }}
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: test-run-artifacts
           path: tmp

--- a/src/charm.py
+++ b/src/charm.py
@@ -204,9 +204,11 @@ class VsphereCloudProviderCharm(CharmBase):
         for controller in self.collector.manifests.values():
             try:
                 controller.apply_manifests()
-                self.stored.deployed = True
             except ApiError:
                 self.unit.status = WaitingStatus("Waiting for kube-apiserver")
+                _event.defer()
+                return
+        self.stored.deployed = True
 
     def _cleanup(self, _event):
         if self.stored.config_hash:

--- a/src/charm.py
+++ b/src/charm.py
@@ -112,7 +112,7 @@ class VsphereCloudProviderCharm(CharmBase):
             self.unit.set_workload_version(self.collector.short_version)
             self.app.status = ActiveStatus(self.collector.long_version)
 
-    def _kube_control(self, event=None):
+    def _kube_control(self, event):
         self.kube_control.set_auth_request(self.unit.name)
         return self._merge_config(event)
 
@@ -167,7 +167,7 @@ class VsphereCloudProviderCharm(CharmBase):
             return False
         return True
 
-    def _merge_config(self, event=None):
+    def _merge_config(self, event):
         if not self._check_vsphere_relation(event):
             return
 
@@ -194,9 +194,9 @@ class VsphereCloudProviderCharm(CharmBase):
 
         self.stored.config_hash = new_hash
         self.stored.deployed = False
-        self._install_or_upgrade()
+        self._install_or_upgrade(event)
 
-    def _install_or_upgrade(self, _event=None):
+    def _install_or_upgrade(self, event):
         if not self.stored.config_hash:
             return
         self.unit.status = MaintenanceStatus("Deploying vSphere Cloud Provider")
@@ -206,7 +206,7 @@ class VsphereCloudProviderCharm(CharmBase):
                 controller.apply_manifests()
             except ApiError:
                 self.unit.status = WaitingStatus("Waiting for kube-apiserver")
-                _event.defer()
+                event.defer()
                 return
         self.stored.deployed = True
 

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -3,7 +3,16 @@
 import unittest.mock as mock
 
 import pytest
+from lightkube import ApiError
 
+@pytest.fixture()
+def api_error_klass():
+    class TestApiError(ApiError):
+        status = mock.MagicMock()
+
+        def __init__(self):
+            pass
+    yield TestApiError
 
 @pytest.fixture(autouse=True)
 def lk_client():

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -5,6 +5,7 @@ import unittest.mock as mock
 import pytest
 from lightkube import ApiError
 
+
 @pytest.fixture()
 def api_error_klass():
     class TestApiError(ApiError):
@@ -12,7 +13,9 @@ def api_error_klass():
 
         def __init__(self):
             pass
+
     yield TestApiError
+
 
 @pytest.fixture(autouse=True)
 def lk_client():

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -194,6 +194,7 @@ def test_waits_for_config(harness: Harness, lk_client, caplog):
             "Adding storage tolerations from control-plane",
         }
 
+
 def test_install_or_upgrade_apierror(harness: Harness, lk_client, api_error_klass):
     lk_client.apply.side_effect = [mock.MagicMock(), api_error_klass]
     harness.begin_with_initial_hooks()

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -193,3 +193,13 @@ def test_waits_for_config(harness: Harness, lk_client, caplog):
             "Setting storage deployment replicas to 2",
             "Adding storage tolerations from control-plane",
         }
+
+def test_install_or_upgrade_apierror(harness: Harness, lk_client, api_error_klass):
+    lk_client.apply.side_effect = [mock.MagicMock(), api_error_klass]
+    harness.begin_with_initial_hooks()
+    charm = harness.charm
+    charm.stored.config_hash = "mock_hash"
+    mock_event = mock.MagicMock()
+    charm._install_or_upgrade(mock_event)
+    mock_event.defer.assert_called_once()
+    assert isinstance(charm.unit.status, WaitingStatus)

--- a/tox.ini
+++ b/tox.ini
@@ -50,9 +50,7 @@ deps =
     types-backports
     types-dataclasses
 commands =
-    # uncomment the following line if this charm owns a lib
-    # codespell {[vars]lib_path}
-    codespell {toxinidir}/. --skip {toxinidir}/.git --skip {toxinidir}/.tox \
+    codespell {toxinidir} --skip {toxinidir}/.git --skip {toxinidir}/.tox \
       --skip {toxinidir}/build --skip {toxinidir}/lib --skip {toxinidir}/venv \
       --skip {toxinidir}/.mypy_cache --skip {toxinidir}/icon.svg \
       --skip {[vars]cov_path} \


### PR DESCRIPTION
## Issue
When trying to deploy the vSphere-Cloud-Provider charm using the following overlay:
```
description: Charmed Kubernetes overlay to add native vSphere support.
applications:
  kubernetes-control-plane:
    options:
      allow-privileged: "true"
  vsphere-integrator:
    charm: vsphere-integrator
    num_units: 1
    trust: true
  vsphere-cloud-provider:
    charm: vsphere-cloud-provider
relations:
- - vsphere-cloud-provider:certificates
  - easyrsa:client
- - vsphere-cloud-provider:kube-control
  - kubernetes-control-plane:kube-control
- - vsphere-cloud-provider:external-cloud-provider
  - kubernetes-control-plane:external-cloud-provider
- - vsphere-cloud-provider:vsphere-integration
  - vsphere-integrator:clients
```
## Changes
- Handle the APIError exception and set the unit state accordingly.
## Further Information
- Fixes [LP#1999532](https://bugs.launchpad.net/charm-vsphere-cloud-provider/+bug/1999532)