### PR TITLE
ci: remove Docker before running charmcraft

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -36,6 +36,12 @@ jobs:
           sudo lxc network set lxdbr0 ipv6.address none
           sudo usermod -a -G lxd $USER
           sg lxd -c 'lxc version'
+      - name: Remove Docker
+        run: |
+          # https://github.com/canonical/lxd-cloud/blob/f20a64a8af42485440dcbfd370faf14137d2f349/test/includes/lxd.sh#L13-L23
+          sudo rm -rf /etc/docker
+          sudo apt-get purge moby-buildx moby-engine moby-cli moby-compose moby-containerd moby-runc -y
+          sudo iptables -P FORWARD ACCEPT
       - name: Install Charmcraft
         run: |
           sudo snap install charmcraft --classic --channel=latest/stable


### PR DESCRIPTION
Debugging PR for [GHA action failure](https://github.com/charmed-kubernetes/vsphere-cloud-provider/actions/runs/3687822390/jobs/6244566712).

These steps are originally from [here](https://github.com/canonical/lxd-cloud/blob/f20a64a8af42485440dcbfd370faf14137d2f349/test/includes/lxd.sh#L13-L23).  Snapcraft saw the same failure recently.  I think the failure started occurring "suddenly" when the runner `ubuntu-latest` changed from 20.04 to 22.04.

You can see snapcraft's fix [here](https://github.com/snapcore/snapcraft/commit/28f59d3ee58e75fc806977baa332245046b4720f), which was later pushed to the [snapcraft action](https://github.com/snapcore/action-build/pull/51/files).