### PR TITLE
[LP#1999427] retry install-upgrade hook when ManifestClientError occurs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,7 +20,7 @@ jobs:
 
   charmcraft-build:
     name: Build Charm
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Check out code
         uses: actions/checkout@v3

--- a/actions.yaml
+++ b/actions.yaml
@@ -26,3 +26,20 @@ scrub-resources:
       default: ""
       description: |
         Space separated list of kubernetes resource types to filter scrubbing   
+sync-resources:
+  description: |
+    Add kubernetes resources which should be created by this charm which aren't
+    present within the cluster.
+  params:
+    controller:
+      type: string
+      default: ""
+      description: |
+        Filter list based on "storage" manifests.
+    resources:
+      type: string
+      default: ""
+      description: |
+        Space separated list of kubernetes resource types
+        to use a filter during the sync. This helps limit
+        which missing resources are applied.

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,5 @@ ops>=1.3.0,<2.0.0
 lightkube>=0.10.1,<1.0.0
 jsonschema
 pyyaml
-git+https://github.com/canonical/ops-lib-manifest.git@602eb96dcfa54269505923b28d861771879c703d
+git+https://github.com/canonical/ops-lib-manifest.git@0929a0d1483b927783c75cdc5ebe6694b7f26d88
 git+https://github.com/charmed-kubernetes/interface-kube-control.git@6dd289d1c795fdeda1bed17873b8d6562227c829#subdirectory=ops

--- a/src/charm.py
+++ b/src/charm.py
@@ -219,7 +219,7 @@ class VsphereCloudProviderCharm(CharmBase):
                 return
         self.stored.deployed = True
 
-    def _cleanup(self, _event):
+    def _cleanup(self, event):
         if self.stored.config_hash:
             self.unit.status = MaintenanceStatus("Cleaning up vSphere Cloud Provider")
             for controller in self.collector.manifests.values():

--- a/src/charm.py
+++ b/src/charm.py
@@ -6,12 +6,11 @@
 import logging
 from pathlib import Path
 
-from lightkube.core.exceptions import ApiError
 from ops.charm import CharmBase
 from ops.framework import StoredState
 from ops.interface_kube_control import KubeControlRequirer
 from ops.main import main
-from ops.manifests import Collector
+from ops.manifests import Collector, ManifestClientError
 from ops.model import ActiveStatus, BlockedStatus, MaintenanceStatus, WaitingStatus
 
 from config import CharmConfig
@@ -80,6 +79,7 @@ class VsphereCloudProviderCharm(CharmBase):
         self.framework.observe(self.on.list_versions_action, self._list_versions)
         self.framework.observe(self.on.list_resources_action, self._list_resources)
         self.framework.observe(self.on.scrub_resources_action, self._scrub_resources)
+        self.framework.observe(self.on.sync_resources_action, self._sync_resources)
         self.framework.observe(self.on.update_status, self._update_status)
 
         self.framework.observe(self.on.install, self._install_or_upgrade)
@@ -99,6 +99,15 @@ class VsphereCloudProviderCharm(CharmBase):
         manifests = event.params.get("controller", "")
         resources = event.params.get("resources", "")
         return self.collector.scrub_resources(event, manifests, resources)
+
+    def _sync_resources(self, event):
+        manifests = event.params.get("controller", "")
+        resources = event.params.get("resources", "")
+        try:
+            self.collector.apply_missing_resources(event, manifests, resources)
+        except ManifestClientError:
+            msg = "Failed to apply missing resources. API Server unavailable."
+            event.set_results({"result": msg})
 
     def _update_status(self, _):
         if not self.stored.deployed:
@@ -204,7 +213,7 @@ class VsphereCloudProviderCharm(CharmBase):
         for controller in self.collector.manifests.values():
             try:
                 controller.apply_manifests()
-            except ApiError:
+            except ManifestClientError:
                 self.unit.status = WaitingStatus("Waiting for kube-apiserver")
                 event.defer()
                 return
@@ -214,7 +223,12 @@ class VsphereCloudProviderCharm(CharmBase):
         if self.stored.config_hash:
             self.unit.status = MaintenanceStatus("Cleaning up vSphere Cloud Provider")
             for controller in self.collector.manifests.values():
-                controller.delete_manifests(ignore_unauthorized=True)
+                try:
+                    controller.delete_manifests(ignore_unauthorized=True)
+                except ManifestClientError:
+                    self.unit.status = WaitingStatus("Waiting for kube-apiserver")
+                    event.defer()
+                    return
         self.unit.status = MaintenanceStatus("Shutting down")
 
 


### PR DESCRIPTION
[LP#1999427](https://bugs.launchpad.net/bugs/1999427)

* adding sync-resource action which was inexplicably missing
* use 1.0.0 version of ops-lib-manifest