### PR TITLE
Cherry-picking for 1.26+ck1

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -36,6 +36,12 @@ jobs:
           sudo lxc network set lxdbr0 ipv6.address none
           sudo usermod -a -G lxd $USER
           sg lxd -c 'lxc version'
+      - name: Remove Docker
+        run: |
+          # https://github.com/canonical/lxd-cloud/blob/f20a64a8af42485440dcbfd370faf14137d2f349/test/includes/lxd.sh#L13-L23
+          sudo rm -rf /etc/docker
+          sudo apt-get purge moby-buildx moby-engine moby-cli moby-compose moby-containerd moby-runc -y
+          sudo iptables -P FORWARD ACCEPT
       - name: Install Charmcraft
         run: |
           sudo snap install charmcraft --classic --channel=latest/stable

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Install and prepare LXD snap environment
         run: |
           sudo apt-get remove -qy lxd lxd-client | true
@@ -69,9 +69,9 @@ jobs:
     timeout-minutes: 90
     steps:
       - name: Check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Setup Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: 3.8
       - name: Setup operator environment
@@ -103,7 +103,7 @@ jobs:
           mv juju-crashdump-* tmp/ | true
       - name: Upload debug artifacts
         if: ${{ failure() }}
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: test-run-artifacts
           path: tmp

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,7 +20,7 @@ jobs:
 
   charmcraft-build:
     name: Build Charm
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Check out code
         uses: actions/checkout@v3

--- a/README.md
+++ b/README.md
@@ -16,6 +16,12 @@ relation to the [vSphere Integrator charm](https://charmhub.io/vsphere-integrato
 
 ## Deployment
 
+### Quickstart
+The vSphere Cloud Provider subordinate charm can be deployed alongside Charmed Kubernetes using the overlay provided in the [Charmed Kubernetes bundle repository](https://github.com/charmed-kubernetes/bundle/blob/main/overlays/vsphere-overlay.yaml):
+```bash
+juju deploy charmed-kubernetes --overlay vsphere-overlay.yaml
+```
+
 ### The full process
 
 ```bash
@@ -34,7 +40,7 @@ kubectl describe nodes |egrep "Taints:|Name:|Provider"
 
 ### Details
 
-* Requires a `charmed-kubernetes` deployment on a vsphere cloud launched by juju
+* Requires a `charmed-kubernetes` deployment on a vsphere cloud launched by juju with the `allow-privileged` flag enabled.
 * Deploy the `vsphere-integrator` charm into the model using `--trust` so juju provided vsphere credentials
 * Deploy the `vsphere-cloud-provider` charm in the model relating to the integrator and to charmed-kubernetes components
 * Once the model is active/idle, the cloud-provider charm will have successfully deployed the vsphere controller in the kube-system

--- a/actions.yaml
+++ b/actions.yaml
@@ -26,3 +26,20 @@ scrub-resources:
       default: ""
       description: |
         Space separated list of kubernetes resource types to filter scrubbing   
+sync-resources:
+  description: |
+    Add kubernetes resources which should be created by this charm which aren't
+    present within the cluster.
+  params:
+    controller:
+      type: string
+      default: ""
+      description: |
+        Filter list based on "storage" manifests.
+    resources:
+      type: string
+      default: ""
+      description: |
+        Space separated list of kubernetes resource types
+        to use a filter during the sync. This helps limit
+        which missing resources are applied.

--- a/config.yaml
+++ b/config.yaml
@@ -84,3 +84,9 @@ options:
       
       The current release deployed is available by viewing
         juju status vsphere-cloud-provider
+  csi-migration:
+    description: |
+      Enables the CSIMigration feature of the storage-provider allowing
+      the driver plugin to migrate in-tree volumes to the out-of-tree provider.
+    type: string
+    default: "false"

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -3,6 +3,8 @@
 name: vsphere-cloud-provider
 display-name: vSphere Cloud Provider
 summary: Runs the vSphere Cloud Provider in the cluster.
+source: https://github.com/charmed-kubernetes/vsphere-cloud-provider
+issues: https://bugs.launchpad.net/charm-vsphere-cloud-provider
 docs: https://discourse.charmhub.io/t/vsphere-cloud-provider-docs-index/6563
 description: >-
   The vSphere cloud provider provides the Kubernetes cluster access to

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,5 @@ ops>=1.3.0,<2.0.0
 lightkube>=0.10.1,<1.0.0
 jsonschema
 pyyaml
-git+https://github.com/canonical/ops-lib-manifest.git@602eb96dcfa54269505923b28d861771879c703d
+git+https://github.com/canonical/ops-lib-manifest.git@0929a0d1483b927783c75cdc5ebe6694b7f26d88
 git+https://github.com/charmed-kubernetes/interface-kube-control.git@6dd289d1c795fdeda1bed17873b8d6562227c829#subdirectory=ops

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -3,6 +3,18 @@
 import unittest.mock as mock
 
 import pytest
+from lightkube import ApiError
+
+
+@pytest.fixture()
+def api_error_klass():
+    class TestApiError(ApiError):
+        status = mock.MagicMock()
+
+        def __init__(self):
+            pass
+
+    yield TestApiError
 
 
 @pytest.fixture(autouse=True)

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -6,12 +6,15 @@
 import unittest.mock as mock
 from pathlib import Path
 
+import ops.testing
 import pytest
 import yaml
 from ops.model import BlockedStatus, MaintenanceStatus, WaitingStatus
 from ops.testing import Harness
 
 from charm import VsphereCloudProviderCharm
+
+ops.testing.SIMULATE_CAN_CONNECT = True
 
 
 @pytest.fixture
@@ -159,6 +162,7 @@ def test_waits_for_config(harness: Harness, lk_client, caplog):
             'Applying provider Control Node Selector as gcp.io/my-control-node: ""',
         }
         assert storage_messages == {
+            "Setting CSIMigration to false",
             "Creating storage secret data for server vsphere.local",
             "Creating storage class csi-vsphere-default",
             'Applying storage Control Node Selector as gcp.io/my-control-node: ""',
@@ -187,6 +191,7 @@ def test_waits_for_config(harness: Harness, lk_client, caplog):
             'Applying provider Control Node Selector as juju-application: "kubernetes-control-plane"',
         }
         assert storage_messages == {
+            "Setting CSIMigration to false",
             "Creating storage secret data for server 1.2.3.4",
             "Creating storage class csi-vsphere-default",
             'Applying storage Control Node Selector as juju-application: "kubernetes-control-plane"',

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -193,3 +193,14 @@ def test_waits_for_config(harness: Harness, lk_client, caplog):
             "Setting storage deployment replicas to 2",
             "Adding storage tolerations from control-plane",
         }
+
+
+def test_install_or_upgrade_apierror(harness: Harness, lk_client, api_error_klass):
+    lk_client.apply.side_effect = [mock.MagicMock(), api_error_klass]
+    harness.begin_with_initial_hooks()
+    charm = harness.charm
+    charm.stored.config_hash = "mock_hash"
+    mock_event = mock.MagicMock()
+    charm._install_or_upgrade(mock_event)
+    mock_event.defer.assert_called_once()
+    assert isinstance(charm.unit.status, WaitingStatus)

--- a/tox.ini
+++ b/tox.ini
@@ -50,9 +50,7 @@ deps =
     types-backports
     types-dataclasses
 commands =
-    # uncomment the following line if this charm owns a lib
-    # codespell {[vars]lib_path}
-    codespell {toxinidir}/. --skip {toxinidir}/.git --skip {toxinidir}/.tox \
+    codespell {toxinidir} --skip {toxinidir}/.git --skip {toxinidir}/.tox \
       --skip {toxinidir}/build --skip {toxinidir}/lib --skip {toxinidir}/venv \
       --skip {toxinidir}/.mypy_cache --skip {toxinidir}/icon.svg \
       --skip {[vars]cov_path} \


### PR DESCRIPTION
This is a complicated set of commits because this repo wasn't squashing commits for a merged PR by default.

I've updated the repo attributes to squash commits now, but in order to prepare this charm for 1.26+ck1, using a PR seems the best way


This covers the backport-needed for:
* LP#1999427
* LP#1999532
* LP#2002440
