### PR TITLE
Use ops lib manifest 1.1.0 in order to use address LP#2010233

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -92,7 +92,7 @@ jobs:
         with:
           name: vsphere-cloud-provider.charm
       - name: Run test
-        run: tox -e integration
+        run: tox -e integration -- --basetemp=/home/ubuntu/pytest
       - name: Setup Debug Artifact Collection
         if: ${{ failure() }}
         run: mkdir tmp

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,62 +18,21 @@ jobs:
     needs: 
       - call-inclusive-naming-check
 
-  charmcraft-build:
-    name: Build Charm
-    runs-on: ubuntu-22.04
-    steps:
-      - name: Check out code
-        uses: actions/checkout@v3
-      - name: Install and prepare LXD snap environment
-        run: |
-          sudo apt-get remove -qy lxd lxd-client | true
-          sudo snap list lxd | true
-          sudo snap install lxd --channel=latest/stable
-          sudo snap refresh lxd --channel=latest/stable
-          sudo lxd waitready
-          sudo lxd init --auto
-          sudo chmod a+wr /var/snap/lxd/common/lxd/unix.socket
-          sudo lxc network set lxdbr0 ipv6.address none
-          sudo usermod -a -G lxd $USER
-          sg lxd -c 'lxc version'
-      - name: Remove Docker
-        run: |
-          # https://github.com/canonical/lxd-cloud/blob/f20a64a8af42485440dcbfd370faf14137d2f349/test/includes/lxd.sh#L13-L23
-          sudo rm -rf /etc/docker
-          sudo apt-get purge moby-buildx moby-engine moby-cli moby-compose moby-containerd moby-runc -y
-          sudo iptables -P FORWARD ACCEPT
-      - name: Install Charmcraft
-        run: |
-          sudo snap install charmcraft --classic --channel=latest/stable
-      - name: Build Charm
-        run: |
-          sg lxd -c 'charmcraft pack -v'
-      - name: Upload charm artifact
-        uses: actions/upload-artifact@v3
-        with:
-          name: vsphere-cloud-provider.charm
-          path: ./vsphere-cloud-provider*.charm
-      - name: Upload debug artifacts
-        if: ${{ failure() }}
-        uses: actions/upload-artifact@v3
-        with:
-          name: charmcraft-logs
-          path: /home/runner/snap/charmcraft/common/cache/charmcraft/log/charmcraft-*.log
-
   integration-test:
     name: VSphere Integration Test
     needs: 
-      - charmcraft-build
       - lint-unit
     runs-on: self-hosted
     timeout-minutes: 90
     steps:
       - name: Check out code
         uses: actions/checkout@v3
+
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
           python-version: 3.8
+
       - name: Setup operator environment
         uses: charmed-kubernetes/actions-operator@main
         with:
@@ -87,21 +46,21 @@ jobs:
             --model-default datastore=vsanDatastore
             --model-default primary-network=VLAN_2763
             --model-default force-vm-hardware-version=17
-      - name: Download charm artifact
-        uses: actions/download-artifact@v3
-        with:
-          name: vsphere-cloud-provider.charm
+
       - name: Run test
         run: tox -e integration -- --basetemp=/home/ubuntu/pytest
+
       - name: Setup Debug Artifact Collection
         if: ${{ failure() }}
         run: mkdir tmp
+
       - name: Collect Juju Status
         if: ${{ failure() }}
         run: |
           juju status 2>&1 | tee tmp/juju-status.txt
           juju-crashdump -s -m controller -a debug-layer -a config -o tmp/
           mv juju-crashdump-* tmp/ | true
+
       - name: Upload debug artifacts
         if: ${{ failure() }}
         uses: actions/upload-artifact@v3

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -78,11 +78,12 @@ jobs:
         uses: charmed-kubernetes/actions-operator@main
         with:
           provider: vsphere
+          juju-channel: 3.1/stable
           credentials-yaml: ${{ secrets.CREDENTIALS_YAML }}
           clouds-yaml: ${{ secrets.CLOUDS_YAML }}
           bootstrap-constraints: "arch=amd64 cores=2 mem=4G"
           bootstrap-options: >-
-            ${{ secrets.FOCAL_BOOTSTRAP_OPTIONS }}
+            ${{ secrets.JAMMY_BOOTSTRAP_OPTIONS }}
             --model-default datastore=vsanDatastore
             --model-default primary-network=VLAN_2763
             --model-default force-vm-hardware-version=17

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,5 @@ ops>=1.3.0,<2.0.0
 lightkube>=0.10.1,<1.0.0
 jsonschema
 pyyaml
-git+https://github.com/canonical/ops-lib-manifest.git@a02d83af8febeed39b7324b0247368cfc7105d73
+ops.manifest
 git+https://github.com/charmed-kubernetes/interface-kube-control.git@6dd289d1c795fdeda1bed17873b8d6562227c829#subdirectory=ops

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,5 @@ ops>=1.3.0,<2.0.0
 lightkube>=0.10.1,<1.0.0
 jsonschema
 pyyaml
-ops.manifest
+ops.manifest>=1.1.0,<2.0.0
 git+https://github.com/charmed-kubernetes/interface-kube-control.git@6dd289d1c795fdeda1bed17873b8d6562227c829#subdirectory=ops


### PR DESCRIPTION
[LP#2010233](https://bugs.launchpad.net/charm-vsphere-cloud-provider/+bug/2010233)
Uses changes to ops lib manifest to address issues with invalid image registry names
