### PR TITLE
Mark charm deployed after successfully running the sync resources action

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -108,6 +108,8 @@ class VsphereCloudProviderCharm(CharmBase):
         except ManifestClientError:
             msg = "Failed to apply missing resources. API Server unavailable."
             event.set_results({"result": msg})
+        else:
+            self.stored.deployed = True
 
     def _update_status(self, _):
         if not self.stored.deployed:


### PR DESCRIPTION
Addresses [LP#2009965](https://bugs.launchpad.net/charm-vsphere-cloud-provider/+bug/2009965)

If a charm is installed and all its hooks (install, relations, config change  hooks...) complete without ever finishing installing the manifests, a sync-resources actions may be necessary. 

When that action is run, ensure to set the `deployed` state to True so that the update_status hook can run successfully.