### PR TITLE
[LP#2039667] Provide charm config parameters on the default storage class

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -85,9 +85,22 @@ options:
       The current release deployed is available by viewing
         juju status vsphere-cloud-provider
 
+  storage-class-parameters:
+    type: string
+    description: |
+      Specify extra parmeters to the default storage class installed. 
+      Each parameter is separated by commas and are key=value pairs
+
+      example)
+        storagepolicyname=vSAN Default Storage Policy
+        storagepolicyname=vSAN Default Storage Policy,datastoreurl=ds:///vmfs/volumes/vsan:52cdfa80721ff516-ea1e993113acfc77/
+
+    default: 'storagepolicyname=vSAN Default Storage Policy'
+
   csi-migration:
     description: |
       Enables the CSIMigration feature of the storage-provider allowing
       the driver plugin to migrate in-tree volumes to the out-of-tree provider.
     type: string
     default: "false"
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ show_missing = true
 [tool.pytest.ini_options]
 minversion = "6.0"
 log_cli_level = "INFO"
+asyncio_mode = "auto"
 
 # Formatting tools configuration
 [tool.black]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,6 @@ show_missing = true
 [tool.pytest.ini_options]
 minversion = "6.0"
 log_cli_level = "INFO"
-asyncio_mode = "auto"
 
 # Formatting tools configuration
 [tool.black]

--- a/src/charm.py
+++ b/src/charm.py
@@ -217,7 +217,7 @@ class VsphereCloudProviderCharm(CharmBase):
                 controller.apply_manifests()
             except ManifestClientError as e:
                 self.unit.status = WaitingStatus("Waiting for kube-apiserver")
-                log.warn(f"Encountered retryable installation error: {e}")
+                log.warning(f"Encountered retryable installation error: {e}")
                 event.defer()
                 return False
         return True

--- a/src/storage_manifests.py
+++ b/src/storage_manifests.py
@@ -131,8 +131,11 @@ class CreateStorageClass(Addition):
         parameter_config = self.manifests.config["storage-class-parameters"]
         parameters = {}
         for param in parameter_config.split(","):
-            key, val = param.split("=", 1)
-            parameters[key] = val
+            try:
+                key, val = param.split("=", 1)
+                parameters[key] = val
+            except ValueError:
+                log.error("Storage class parameter missing '=' separator in '%s'", param)
         return parameters
 
     def __call__(self) -> Optional[AnyResource]:

--- a/src/storage_manifests.py
+++ b/src/storage_manifests.py
@@ -126,6 +126,15 @@ class CreateStorageClass(Addition):
         super().__init__(manifests)
         self.type = sc_type
 
+    @property
+    def _params(self) -> Dict[str, str]:
+        parameter_config = self.manifests.config["storage-class-parameters"]
+        parameters = {}
+        for param in parameter_config.split(","):
+            key, val = param.split("=", 1)
+            parameters[key] = val
+        return parameters
+
     def __call__(self) -> Optional[AnyResource]:
         """Craft the storage class object."""
         storage_name = STORAGE_CLASS_NAME.format(type=self.type)
@@ -141,7 +150,7 @@ class CreateStorageClass(Addition):
                     },
                 ),
                 provisioner="csi.vsphere.vmware.com",
-                parameters=dict(storagepolicyname="vSAN Default Storage Policy"),
+                parameters=self._params,
             )
         )
 

--- a/tests/unit/test_storage_manifests.py
+++ b/tests/unit/test_storage_manifests.py
@@ -1,0 +1,26 @@
+# Copyright 2023 Canonical Ltd.
+# See LICENSE file for licensing details.
+#
+# Learn more about testing at: https://juju.is/docs/sdk/testing
+
+
+from unittest import mock
+
+from storage_manifests import CreateStorageClass
+
+
+def test_parse_parameter_config():
+    mock_manifests = mock.MagicMock()
+    mock_manifests.config = {"storage-class-parameters": "key=val,something=test with spaces"}
+    sc = CreateStorageClass(mock_manifests, "default")
+    assert sc._params == {"key": "val", "something": "test with spaces"}
+
+
+def test_parse_parameter_invalid(caplog):
+    mock_manifests = mock.MagicMock()
+    mock_manifests.config = {"storage-class-parameters": "key=val,something"}
+    sc = CreateStorageClass(mock_manifests, "default")
+    assert sc._params == {"key": "val"}
+    error_logs = [rec for rec in caplog.records if rec.levelname == "ERROR"]
+    assert len(error_logs) == 1, "Expect one error"
+    assert error_logs[0].message == "Storage class parameter missing '=' separator in 'something'"

--- a/upstream/update.py
+++ b/upstream/update.py
@@ -88,7 +88,7 @@ class Release:
         return hash(self.name)
 
     def __eq__(self, other) -> bool:
-        """Comparible based on its name."""
+        """Comparable based on its name."""
         return isinstance(other, Release) and self.name == other.name
 
     def __lt__(self, other) -> bool:


### PR DESCRIPTION
[LP#2039667](https://bugs.launchpad.net/charm-vsphere-cloud-provider/+bug/2039667)

Allows the user to configure arbitrary parameters on the default storage class installed